### PR TITLE
Add alt text and presentation roles for images

### DIFF
--- a/basic.html
+++ b/basic.html
@@ -44,14 +44,14 @@
       <h1>基础</h1>
       <p class="muted">从原理到器件的系统化导读。</p>
       <div class="grid" style="grid-template-columns:repeat(3,1fr)">
-        <a class="card" href="basics/what-is-semiconductor.html"><img src="assets/img/basic.png" alt=""><h3 id="s1">半导体是什么</h3><p>导体vs绝缘体、带隙与温度/掺杂影响。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/crystal-band.html"><img src="assets/img/basic.png" alt=""><h3 id="s2">晶体与能带</h3><p>硅的金刚石结构与能带模型。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/carrier-doping.html"><img src="assets/img/basic.png" alt=""><h3 id="s3">载流子与掺杂</h3><p>费米能级、迁移率与浓度。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/pn-diode.html"><img src="assets/img/basic.png" alt=""><h3 id="s4">PN 结与二极管</h3><p>耗尽层、I–V 特性与整流。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/bjt.html"><img src="assets/img/basic.png" alt=""><h3 id="s5">BJT 与放大</h3><p>偏置点、小信号模型与放大。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/mosfet.html"><img src="assets/img/basic.png" alt=""><h3 id="s6">MOSFET 与开关</h3><p>阈值、沟道调制与短沟道效应。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/logic.html"><img src="assets/img/basic.png" alt=""><h3 id="s7">数字逻辑</h3><p>与或非、时序逻辑与触发器。</p><span class="more">进入</span></a>
-        <a class="card" href="basics/ic.html"><img src="assets/img/basic.png" alt=""><h3 id="s8">从器件到 IC</h3><p>版图、互连、功耗与 SoC。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/what-is-semiconductor.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s1">半导体是什么</h3><p>导体vs绝缘体、带隙与温度/掺杂影响。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/crystal-band.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s2">晶体与能带</h3><p>硅的金刚石结构与能带模型。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/carrier-doping.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s3">载流子与掺杂</h3><p>费米能级、迁移率与浓度。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/pn-diode.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s4">PN 结与二极管</h3><p>耗尽层、I–V 特性与整流。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/bjt.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s5">BJT 与放大</h3><p>偏置点、小信号模型与放大。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/mosfet.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s6">MOSFET 与开关</h3><p>阈值、沟道调制与短沟道效应。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/logic.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s7">数字逻辑</h3><p>与或非、时序逻辑与触发器。</p><span class="more">进入</span></a>
+        <a class="card" href="basics/ic.html"><img src="assets/img/basic.png" alt="" role="presentation"><h3 id="s8">从器件到 IC</h3><p>版图、互连、功耗与 SoC。</p><span class="more">进入</span></a>
       </div>
     </section>
   </div>

--- a/equipment.html
+++ b/equipment.html
@@ -30,7 +30,7 @@
   <h1>设备</h1>
   <p class="muted">这里是 设备 页面的占位内容。请替换为实际内容与链接。</p>
   <div class="grid">
-    <div class="card"><img src="assets/img/equipment.png" alt=""><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
+    <div class="card"><img src="assets/img/equipment.png" alt="设备模块插图"><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
   </div>
 </section>
 </main>

--- a/glossary.html
+++ b/glossary.html
@@ -30,7 +30,7 @@
   <h1>术语</h1>
   <p class="muted">这里是 术语 页面的占位内容。请替换为实际内容与链接。</p>
   <div class="grid">
-    <div class="card"><img src="assets/img/glossary.png" alt=""><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
+    <div class="card"><img src="assets/img/glossary.png" alt="术语模块插图"><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
   </div>
 </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         </div>
       </div>
       <figure class="hero-media">
-        <img src="assets/img/hero.jpg" alt="示意图：蓝白背景上的电路/晶圆抽象图">
+        <img src="assets/img/hero.jpg" alt="蓝白背景的电路晶圆示意图">
       </figure>
     </div>
   </main>
@@ -80,7 +80,7 @@
       <div class="grid4">
         <a class="card" href="basic.html">
           <span class="badge">基础</span>
-          <figure class="card-media"><img src="assets/img/card1.jpg" alt=""></figure>
+          <figure class="card-media"><img src="assets/img/card1.jpg" alt="基础知识插图"></figure>
           <div class="card-body">
             <h3>基础知识</h3>
             <p class="muted">能带、PN结、MOS、版图与器件基础。</p>
@@ -88,7 +88,7 @@
         </a>
         <a class="card" href="process.html">
           <span class="badge" data-variant="accent">工艺</span>
-          <figure class="card-media"><img src="assets/img/card2.jpg" alt=""></figure>
+          <figure class="card-media"><img src="assets/img/card2.jpg" alt="工艺流程插图"></figure>
           <div class="card-body">
             <h3>工艺流程</h3>
             <p class="muted">氧化、薄膜、光刻、刻蚀、注入到金属互连。</p>
@@ -96,7 +96,7 @@
         </a>
         <a class="card" href="equipment.html">
           <span class="badge" data-variant="warm">设备</span>
-          <figure class="card-media"><img src="assets/img/card3.jpg" alt=""></figure>
+          <figure class="card-media"><img src="assets/img/card3.jpg" alt="设备插图"></figure>
           <div class="card-body">
             <h3>设备</h3>
             <p class="muted">炉管、刻蚀、光刻、量测等设备原理与要点。</p>
@@ -104,7 +104,7 @@
         </a>
         <a class="card" href="materials.html">
           <span class="badge" data-variant="violet">材料</span>
-          <figure class="card-media"><img src="assets/img/card4.jpg" alt=""></figure>
+          <figure class="card-media"><img src="assets/img/card4.jpg" alt="材料插图"></figure>
           <div class="card-body">
             <h3>材料</h3>
             <p class="muted">硅、介质、金属与化学品的性质与应用。</p>
@@ -118,9 +118,9 @@
     <div class="container">
       <h2>最新内容</h2>
       <div class="posts">
-        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post1.jpg" alt=""></figure><div><h4>热氧化：Deal–Grove 与 Massoud</h4><div class="meta muted">工艺 · 2025-08-28 · 8 分钟</div></div></a>
-        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post2.jpg" alt=""></figure><div><h4>光刻窗口与焦深</h4><div class="meta muted">工艺 · 2025-08-22 · 6 分钟</div></div></a>
-        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post3.jpg" alt=""></figure><div><h4>LPCVD vs. PECVD</h4><div class="meta muted">设备 · 2025-08-19 · 7 分钟</div></div></a>
+        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post1.jpg" alt="热氧化封面图"></figure><div><h4>热氧化：Deal–Grove 与 Massoud</h4><div class="meta muted">工艺 · 2025-08-28 · 8 分钟</div></div></a>
+        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post2.jpg" alt="光刻窗口封面图"></figure><div><h4>光刻窗口与焦深</h4><div class="meta muted">工艺 · 2025-08-22 · 6 分钟</div></div></a>
+        <a class="post" href="#"><figure class="post-cover"><img src="assets/img/post3.jpg" alt="LPCVD 与 PECVD 封面图"></figure><div><h4>LPCVD vs. PECVD</h4><div class="meta muted">设备 · 2025-08-19 · 7 分钟</div></div></a>
       </div>
     </div>
   </section>

--- a/materials.html
+++ b/materials.html
@@ -30,7 +30,7 @@
   <h1>材料</h1>
   <p class="muted">这里是 材料 页面的占位内容。请替换为实际内容与链接。</p>
   <div class="grid">
-    <div class="card"><img src="assets/img/materials.png" alt=""><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
+    <div class="card"><img src="assets/img/materials.png" alt="材料模块插图"><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
   </div>
 </section>
 </main>

--- a/process.html
+++ b/process.html
@@ -30,7 +30,7 @@
   <h1>工艺</h1>
   <p class="muted">这里是 工艺 页面的占位内容。请替换为实际内容与链接。</p>
   <div class="grid">
-    <div class="card"><img src="assets/img/process.png" alt=""><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
+    <div class="card"><img src="assets/img/process.png" alt="工艺模块插图"><h3>示例模块</h3><p>替换为你的实际模块。</p></div>
   </div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- Add descriptive alt text to hero, category, and post images on the homepage
- Describe module icons on equipment, glossary, materials, and process pages
- Mark repeated basic page icons as decorative with `role="presentation"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc37133de883288c320313514a72d2