### PR TITLE
Add placeholder search results page

### DIFF
--- a/search.html
+++ b/search.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>搜索 | 半导体知识站</title>
+  <meta name="description" content="搜索结果 - 半导体知识站" />
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="nav">
+    <div class="container nav-inner">
+      <a class="brand" href="index.html" aria-label="首页">
+        <span class="brand-logo" aria-hidden="true"></span>
+        <span>半导体知识站</span>
+      </a>
+
+      <nav class="nav-links" aria-label="主导航">
+        <a href="index.html">首页</a>
+
+        <span class="dropdown">
+          <a class="dd-link" href="basic.html">基础</a>
+          <button class="caret-btn" aria-label="展开基础" aria-expanded="false" aria-controls="menu-basic">▾</button>
+          <div class="menu" id="menu-basic" role="menu">
+            <a href="basic.html#top">返回目录</a>
+            <a href="basic.html#step1-what">STEP1 半导体是什么</a>
+            <a href="basic.html#step2-materials">STEP2 材料</a>
+            <a href="basic.html#step3-np">STEP3 n/p 型</a>
+            <a href="basic.html#step4-bands">STEP4 能带</a>
+            <a href="basic.html#step5-bands-np">STEP5 n/p 能带</a>
+            <a href="basic.html#step6-pn">STEP6 PN 结</a>
+            <a href="basic.html#step7-bias">STEP7 偏置</a>
+            <a href="basic.html#step8-breakdown">STEP8 击穿</a>
+          </div>
+        </span>
+
+        <span class="dropdown">
+          <a class="dd-link" href="process.html">工艺</a>
+          <button class="caret-btn" aria-label="展开工艺" aria-expanded="false" aria-controls="menu-process">▾</button>
+          <div class="menu" id="menu-process" role="menu">
+            <a href="process.html#oxidation">热氧化</a>
+            <a href="process.html#deposition">薄膜沉积</a>
+            <a href="process.html#lithography">光刻</a>
+            <a href="process.html#etch">刻蚀与注入</a>
+          </div>
+        </span>
+
+        <a href="equipment.html">设备</a>
+        <a href="materials.html">材料</a>
+      </nav>
+
+      <div class="nav-right">
+        <form class="search" action="search.html" method="get" role="search">
+          <input name="q" type="search" placeholder="搜索：氧化、光刻、LPCVD…" aria-label="站内搜索" />
+          <span class="icon">🔎</span>
+        </form>
+      </div>
+    </div>
+  </header>
+
+  <main class="section">
+    <div class="container">
+      <h1>搜索结果</h1>
+      <p class="muted">搜索功能暂未开放，以下为占位内容。</p>
+      <div class="posts" style="margin-top:20px;">
+        <a class="post" href="#">
+          <figure class="post-cover"><img src="assets/img/post1.jpg" alt=""></figure>
+          <div>
+            <h4>示例结果标题</h4>
+            <div class="meta muted">分类 · 日期 · 时长</div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="foot">
+        <div class="brand"><span class="brand-logo"></span><span>半导体知识站</span></div>
+        <div class="foot-muted">© 2025 All rights reserved.</div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+  // Split interaction: text navigates, caret toggles menu
+  (function(){
+    function closeAll(except){
+      document.querySelectorAll('.dropdown.open').forEach(function(x){
+        if(x!==except){ x.classList.remove('open'); const b=x.querySelector('.caret-btn'); if(b) b.setAttribute('aria-expanded','false'); }
+      });
+    }
+    document.querySelectorAll('.dropdown .caret-btn').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        e.preventDefault(); e.stopPropagation();
+        const dd = btn.closest('.dropdown');
+        const willOpen = !dd.classList.contains('open');
+        closeAll(dd);
+        dd.classList.toggle('open', willOpen);
+        btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+      });
+    });
+    document.addEventListener('click', function(e){
+      if(!e.target.closest('.dropdown')){ closeAll(null); }
+    });
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `search.html` with shared header/footer and placeholder search results
- wire search form to the new page since search functionality isn't implemented yet

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc370cb6e883288e0b5c243d8ec3cb