### PR TITLE
Add meta descriptions to key pages

### DIFF
--- a/basic.html
+++ b/basic.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="系统讲解半导体基础知识，从材料结构、能带理论到器件物理与数字逻辑，通过图示与示例帮助入门者快速理解芯片工作原理与设计思路。">
 <title>基础 · 半导体学习网</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/equipment.html
+++ b/equipment.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="介绍半导体制造中常见的关键设备，如光刻机、刻蚀机、离子注入与测量仪，说明其工作原理与应用场景，帮助理解设备对工艺的影响。">
 <title>设备 · 半导体学习网</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/glossary.html
+++ b/glossary.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="收录半导体领域常见术语与缩写，提供通俗解释和关联概念，便于快速查阅与建立知识网络，是初学者与工程师的随身词典。">
 <title>术语 · 半导体学习网</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/materials.html
+++ b/materials.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="概览半导体材料的种类与特性，涵盖硅、砷化镓等主流材料，以及介电层、金属互连等辅助材料，帮助学习者理解材料选择对器件性能的影响。">
 <title>材料 · 半导体学习网</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/process.html
+++ b/process.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="概述半导体制造的核心工艺流程，包括光刻、刻蚀、沉积、扩散等步骤，帮助初学者建立完整流程概念并理解各环节作用。">
 <title>工艺 · 半导体学习网</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>


### PR DESCRIPTION
## Summary
- add meaningful meta description tags to process, equipment, materials, glossary, and basic pages for better SEO

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3709055c83288531803e78d0945d